### PR TITLE
fix warning about unsafe variable

### DIFF
--- a/lib/lex_luthor.ex
+++ b/lib/lex_luthor.ex
@@ -153,8 +153,10 @@ defmodule LexLuthor do
 
   defp rules_for_state rules, state do
     Enum.filter rules, fn({rule_state,_,_})->
-      if is_nil(state) do
-        state = :default
+      state = if is_nil(state) do
+        :default
+      else
+        state
       end
       state == rule_state
     end


### PR DESCRIPTION
Thank you for `lex_luthor`! This fixes a warning I receive when compiling.

```
> elixir --version
Erlang/OTP 19 [erts-8.0.2] [source] [64-bit] [smp:4:4] [async-threads:10] [hipe] [kernel-poll:false] [dtrace]

Elixir 1.3.2
```

```
warning: the variable "state" is unsafe as it has been set inside a case/cond/receive/if/&&/||. Please explicitly return the variable value instead. For example:

    case int do
      1 -> atom = :one
      2 -> atom = :two
    end

should be written as

    atom =
      case int do
        1 -> :one
        2 -> :two
      end

Unsafe variable found at:
  lib/lex_luthor.ex:159
```
